### PR TITLE
Place allay on block & NoAI tag copy

### DIFF
--- a/src/aiab.mc
+++ b/src/aiab.mc
@@ -281,7 +281,6 @@ advancement release {
 dir core {
   function load {
 
-    say aiab Loaded
     log AllayInABottle info server <Datapack reloaded>
 
     scoreboard objectives add aiab.data dummy

--- a/src/aiab.mc
+++ b/src/aiab.mc
@@ -229,7 +229,7 @@ function release {
     name placemob
 
     execute if entity @p[distance=..4.5] unless block ^ ^ ^0.25 air if block ~ ~ ~ air run {
-      summon minecraft:allay ^ ^-0.2 ^ {Tags: ["aiab.init"]}
+      summon minecraft:allay ^ ^-0.2 ^-0.2 {Tags: ["aiab.init"]}
       particle minecraft:end_rod ~ ~0.2 ~ 0.2 0.4 0.2 0 4
     }
     execute if block ^ ^ ^0.25 air positioned ^ ^ ^0.25 run function aiab:placemob


### PR DESCRIPTION
added the more vanilla behavior when placing the bottled allay as discussed in the issue I opened previously
added a nested iterative function, within the release function, that checks every 0.25 block along player eyes vector for max of 4.5 blocks (survival player range) until it encounters a block, then summons the allay 0.2 blocks back along that vector, so that the allay isn't placed inside the block

then if the allay tagged aiab.init was placed (is present distance of 5 blocks around the player) the rest of the function runs (copying tags etc)

only weird consequence now is the player "drinks" the honey bottle (ie the animation & sound play) if you hold right click without placing on a block. But nothing happens to the item

also added NoAI tag to the tags copied over, for testing purposes, left it in as it can be useful