### PR TITLE
Place allay directly in minecart

### DIFF
--- a/src/aiab.mc
+++ b/src/aiab.mc
@@ -238,8 +238,21 @@ function release {
 
         summon minecraft:allay ^ ^-0.2 ^-0.2 {Tags: ["aiab.init"]}
         particle minecraft:end_rod ~ ~0.2 ~ 0.2 0.4 0.2 0 4
+
       } else {
-        execute positioned ^ ^ ^0.1 run function aiab:place_mob
+        execute(as @e[type=minecart,dx=0] positioned ~-0.99 ~-0.99 ~-0.99 if entity @s[type=minecart,dx=0] positioned ~0.99 ~0.99 ~0.99){
+          scoreboard players set .success aiab.data 1
+          data modify storage aiab:data root set from entity @s
+          execute at @e[type=minecart,dx=0] run summon minecart ~ ~ ~ {Tags: ["aiab.cartinit"],Passengers:[{id:"minecraft:allay",Tags: ["aiab.init"]}]}
+          kill @s
+          execute as @e[type=minecart,tag=aiab.cartinit] run {
+            data modify entity @s Motion set from storage aiab:data root.Motion
+            data modify entity @s Rotation set from storage aiab:data root.Rotation
+            tag @s remove aiab.cartinit
+          }
+        } else {  
+           execute positioned ^ ^ ^0.1 run function aiab:place_mob
+         }
       }
     }
   }

--- a/src/aiab.mc
+++ b/src/aiab.mc
@@ -225,7 +225,7 @@ function release {
 
   # Iterative function to find block to place on
   scoreboard players set .success aiab.data 0
-  scoreboard players set .length aiab.data 450
+  scoreboard players set .length aiab.data 45
 
   execute as @p anchored eyes run block {
     name place_mob


### PR DESCRIPTION
A new minecart is summoned in the exact position of the previous minecart with the allay in it, Rotation and Motion data is copied over
Only issue is the minecart rotation is not instant, so it spins into position after being placed, but not much we can do about that, until Mojang allows storage data to be used directly with summon command